### PR TITLE
fix: composter output when fertilizer is disabled

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ yarn_mappings=1.21.1+build.1
 loader_version=0.15.11
 
 # Mod Properties
-mod_version=0.1.5
+mod_version=0.1.6
 maven_group=com.opryshok
 archives_base_name=borukva-food
 

--- a/src/main/java/com/opryshok/mixin/FullComposterInventoryMixin.java
+++ b/src/main/java/com/opryshok/mixin/FullComposterInventoryMixin.java
@@ -1,6 +1,7 @@
 package com.opryshok.mixin;
 
 import com.opryshok.item.ModItems;
+import net.minecraft.item.Items;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.math.Direction;
 import org.spongepowered.asm.mixin.Mixin;
@@ -8,10 +9,13 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
+import static com.opryshok.BorukvaFood.modConfig;
+
 @Mixin(targets = "net.minecraft.block.ComposterBlock$FullComposterInventory")
 public class FullComposterInventoryMixin {
     @Inject(method = "canExtract", at = @At("HEAD"), cancellable = true)
     public void canExtract(int slot, ItemStack stack, Direction dir, CallbackInfoReturnable<Boolean> cir){
-        cir.setReturnValue(dir == Direction.DOWN && stack.isOf(ModItems.COMPOST));
+        var item = modConfig.isReplaceCompostOutputWithFertilizer() ? ModItems.COMPOST : Items.BONE_MEAL;
+        cir.setReturnValue(dir == Direction.DOWN && stack.isOf(item));
     }
 }


### PR DESCRIPTION
When `replaceCompostOutputWithFertilizer` is disabled in the config, the produced bonemeal cannot be extracted from composters. This change reintroduces the vanilla behaviour to composters when fertilizer is disabled.