### PR TITLE
Created Brazilian Portuguese Translation

### DIFF
--- a/src/main/resources/assets/borukva-food/lang/pt_br.json
+++ b/src/main/resources/assets/borukva-food/lang/pt_br.json
@@ -69,7 +69,7 @@
   "item.borukva-food.pickle": "Picles",
   "item.borukva-food.apple_candy": "Maçã Caramelizada",
   "item.borukva-food.honey_candy": "Doce de Mel",
-  "item.borukva-food.jack_candy": "Doce Jack",
+  "item.borukva-food.jack_candy": "Barra de Waffle com Chocolate",
   "item.borukva-food.pumpkin_candy": "Doce de Abóbara",
   "item.borukva-food.lemon_candy": "Doce de Limão",
   "item.borukva-food.cooked_beef_slices": "Fatias de Bife Cozidas",


### PR DESCRIPTION
Things to note:
- Lemon and Avocado wood types have been renamed to "Lemontree" and "Avocadotree", Limoeiro and Abacateiro. This is because Brazilian Portuguese does not call them, literally, "Lemon Wood" (Madeira de Limão), but rather "Lemontree Wood" (Madeira de Limoeiro).
- Items that have names that aren't commonly translated in Portuguese have kept their original names. Sauerkraut -> Chucrute, but Shawarma stays the same, instead of being translated as Xauarma, which isn't commonly seen.
- Jack Candy has been renamed "Barra de Waffle com Chocolate", literally Chocolate Waffle (Candy) Bar, because I have no idea of what it is. If it's a trademark, it's not one I've ever seen in Brazil. The name has been created from the recipe, which uses waffle and a chocolate bar.