### PR TITLE
Sickle Callbacks (1.21.1)

### DIFF
--- a/src/main/java/com/opryshok/item/HarvestSickleItem.java
+++ b/src/main/java/com/opryshok/item/HarvestSickleItem.java
@@ -97,8 +97,9 @@ public class HarvestSickleItem extends ToolItem implements PolymerItem {
                             BlockPos targetPos = pos.add(dx, 0, dz);
                             BlockState state = world.getBlockState(targetPos);
 
-                            if (state.getBlock() instanceof PlantBlock) {
+                            if (state.getBlock() instanceof PlantBlock && sickleStack.getItem().canMine(state, world, targetPos, player)) {
                                 world.breakBlock(targetPos, true, player);
+                                sickleStack.getItem().postMine(sickleStack, world, state, targetPos, player);
                                 if(FabricLoader.getInstance().isModLoaded("ledger")) {
                                     BlockBreakCallback.EVENT.invoker().breakBlock(world, targetPos, state, world.getBlockEntity(targetPos), player);
                                 }


### PR DESCRIPTION
Context: postMine and canMine are important callbacks for block breaking. Other mods may use this functions in mixins.

This PR increases mod compatibilty for sickles by making it respect the two callbacks mentioned. Durability loss is unaffected.